### PR TITLE
New Version Number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="readysignal",
-    version="1.4.1",
+    version="1.5.0",
     author="Jess Brown",
     author_email="jess.brown@rxa.io",
     description="The API for readysignal.com",


### PR DESCRIPTION
For the PyPI deployment to work, I needed to add a new version number to `setup.py`.