### PR TITLE
Update __init__.py

### DIFF
--- a/readysignal/__init__.py
+++ b/readysignal/__init__.py
@@ -202,6 +202,7 @@ def auto_discover(
     df=None,
     create_custom_features=1,
     filtered_geo_grains=None,
+    signal_name=None,
 ):
     """
     Creates a signal using your own data and the Auto Discover feature. Please check Ready Signal site for tips on
@@ -219,6 +220,8 @@ def auto_discover(
     :param create_custom_features: a flag to denote whether or not the target feature will be saved to the
     ready signal platform for reporting reference.
     :param filtered_geo_grains: optional parameter to filter geographic grains: "usa", "nonusa", or "all"
+    :param signal_name: optional parameter to specify a custom name for the signal (max 255 characters).
+    If not provided, the signal name will default to 'Auto-discovery - [custom feature name]'
     :return: requests response object
     """
     base_url = "https://app.readysignal.com/api/auto-discovery"
@@ -243,6 +246,8 @@ def auto_discover(
         }
         if filtered_geo_grains is not None:
             data["filtered_geo_grains"] = filtered_geo_grains
+        if signal_name is not None:
+            data["signal_name"] = signal_name
         
         req = requests.post(
             url,
@@ -262,6 +267,8 @@ def auto_discover(
         }
         if filtered_geo_grains is not None:
             body["filtered_geo_grains"] = filtered_geo_grains
+        if signal_name is not None:
+            body["signal_name"] = signal_name
 
         req = requests.post(
             url,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="readysignal",
-    version="1.5.0",
+    version="1.5.1",
     author="Jess Brown",
     author_email="jess.brown@rxa.io",
     description="The API for readysignal.com",


### PR DESCRIPTION
Changes Made:
1. Added signal_name parameter to the function signature (line 205) as an optional parameter with default value None.

2. Updated the docstring (lines 223-224) to document the new parameter, explaining it's optional and used to specify a custom name for the signal.

3. Added signal_name to file upload requests (lines 249-250) - when using filename, the parameter is included in the data dictionary if provided.

4. Added signal_name to DataFrame upload requests (lines 270-271) - when using df, the parameter is included in the body dictionary if provided.

The implementation follows the same pattern as filtered_geo_grains - it's optional and only sent to the API when provided (not None).